### PR TITLE
Migrate Docker Compose Config to Newer Watch Form

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 4. [Set up the `dev`](#set-up-dev-command) command, or use `docker compose -f docker-compose.development.yml` instead of `dev` in all instructions.
 
-5. Boot the api, web, and db services via `dev up` or `docker compose -f docker-compose.development.yml up`. This will run the boot pipeline and create the database, run migrations, and run seeds.
+5. Boot the api, web, and db services via `dev up --watch` or `dev watch` or `docker compose -f docker-compose.development.yml up --watch`. This will run the boot pipeline and create the database, run migrations, and run seeds.
 
 6. Stop the api, web, and db services via `ctrl+c` or `dev down` or if you want to wipe the database `dev down -v`.
 
@@ -66,7 +66,7 @@
 
    # or
 
-   docker compose -f docker-compose.development.yml up api
+   docker compose -f docker-compose.development.yml up --watch api
 
    # or
 
@@ -85,7 +85,7 @@
 
    # or
 
-   docker compose -f docker-compose.development.yml up web
+   docker compose -f docker-compose.development.yml up --watch web
 
    # or
 
@@ -104,7 +104,7 @@
 
    # or
 
-   docker compose -f docker-compose.development.yml up db
+   docker compose -f docker-compose.development.yml up --watch db
    ```
 
    > Migrations run automatically, as do seeds.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 7. Install local dependencies by installing `asdf` and node via `asdf` and then running `npm install` at the top level of the project.
 
-8. To get the local per-service node_modules, folders run `dev api npm i` and `dev web npm i`. I'm not sure why the previous commands don't do this automatically.
+8. To get the local per-service node_modules, so your code editor gets linting and types, do `cd api && npm i` and `cd web && npm i`.
 
 ### API Service (a.k.a back-end)
 

--- a/bin/dev
+++ b/bin/dev
@@ -54,7 +54,7 @@ class DevHelper
   end
 
   def up(*args, **kwargs)
-    compose(*%w[up --remove-orphans], *args, **kwargs)
+    compose(*%w[up --remove-orphans --watch], *args, **kwargs)
   end
 
   def down(*args, **kwargs)

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -42,14 +42,27 @@ services:
     # stdin_open: true # equivalent of docker exec -i
     ports:
       - "3000:3000"
-    volumes:
-      - ./api:/usr/src/api
-      - ./.gitignore:/usr/src/.gitignore
-      - ./.prettierrc.yaml:/usr/src/.prettierrc.yaml
     depends_on:
       - db
       - mail
       - cache
+    develop:
+      watch: &api-develop-watch
+        - path: ./api
+          target: /usr/src/api
+          action: sync
+          ignore:
+            - node_modules/
+        - path: ./.gitignore
+          target: /usr/src/.gitignore
+          action: sync
+        - path: ./.prettierrc.yaml
+          target: /usr/src/.prettierrc.yaml
+          action: sync
+        - path: ./api/package.json
+          action: rebuild
+        - path: ./api/package-lock.json
+          action: rebuild
 
   web:
     build:
@@ -59,12 +72,25 @@ services:
       <<: *default-environment
     ports:
       - "8080:8080"
-    volumes:
-      - ./web:/usr/src/web
-      - ./.gitignore:/usr/src/.gitignore
-      - ./.prettierrc.yaml:/usr/src/.prettierrc.yaml
     depends_on:
       - api
+    develop:
+      watch:
+        - path: ./web
+          target: /usr/src/web
+          action: sync
+          ignore:
+            - node_modules/
+        - path: ./.gitignore
+          target: /usr/src/.gitignore
+          action: sync
+        - path: ./.prettierrc.yaml
+          target: /usr/src/.prettierrc.yaml
+          action: sync
+        - path: ./web/package.json
+          action: rebuild
+        - path: ./web/package-lock.json
+          action: rebuild
 
   test_api:
     build:
@@ -76,16 +102,16 @@ services:
     environment:
       <<: *default-environment
       NODE_ENV: test
-      DB_DATABASE: digital_vault_test
+      DB_DATABASE: traditional_knowledge_test
       DEFAULT_LOG_LEVEL: "info"
       DB_HEALTH_CHECK_START_PERIOD_SECONDS: 0
     tty: true
-    volumes:
-      - ./api:/usr/src/api
     depends_on:
       - db
       - mail
       - cache
+    develop:
+      watch: *api-develop-watch
 
   # test_web:
   #   build:
@@ -151,14 +177,28 @@ services:
     ports:
       - "5000:5000"
     volumes:
-      - ./archiver:/usr/src/archiver
-      - ./.gitignore:/usr/src/.gitignore
-      - ./.prettierrc.yaml:/usr/src/.prettierrc.yaml
       - ./archiver/certs/icefog.pem:/etc/ssl/private/icefog.pem:ro
       - ./archiver/certs/fullchain.pem:/etc/ssl/certs/fullchain.pem:ro
     depends_on:
       - db
       - cache
+    develop:
+      watch:
+        - path: ./archiver
+          target: /usr/src/archiver
+          action: sync
+          ignore:
+            - node_modules/
+        - path: ./.gitignore
+          target: /usr/src/.gitignore
+          action: sync
+        - path: ./.prettierrc.yaml
+          target: /usr/src/.prettierrc.yaml
+          action: sync
+        - path: ./archiver/package.json
+          action: rebuild
+        - path: ./archiver/package-lock.json
+          action: rebuild
 
 volumes:
   db_data:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -47,7 +47,7 @@ services:
       - mail
       - cache
     develop:
-      watch: &api-develop-watch
+      watch:
         - path: ./api
           target: /usr/src/api
           action: sync
@@ -106,12 +106,24 @@ services:
       DEFAULT_LOG_LEVEL: "info"
       DB_HEALTH_CHECK_START_PERIOD_SECONDS: 0
     tty: true
+    volumes:
+      - ./api:/usr/src/api
     depends_on:
       - db
       - mail
       - cache
     develop:
-      watch: *api-develop-watch
+      watch:
+        - path: ./.gitignore
+          target: /usr/src/.gitignore
+          action: sync
+        - path: ./.prettierrc.yaml
+          target: /usr/src/.prettierrc.yaml
+          action: sync
+        - path: ./api/package.json
+          action: rebuild
+        - path: ./api/package-lock.json
+          action: rebuild
 
   # test_web:
   #   build:


### PR DESCRIPTION
Relates to:

- https://docs.docker.com/compose/how-tos/file-watch/
- https://github.com/nodejs/node/issues/51621

# Context

Docker volume mounts only work when the parent OS is more or less the same as the OS inside the container.
A classic example of this not working is when the node_modules folder gets cloned to the host and doesn't work correctly on windows.

# Implementation

1. Switch to docker compose watch for all services except test_api.
2. Leave cert mounts using readonly volumes so they stay readonly.
3. Leave test_api service using docker volume mount as this works best with vitest watch. Vitest watch does not detect docker watch file sync events see https://github.com/nodejs/node/issues/51621

# Screenshots

![image](https://github.com/user-attachments/assets/e1168efd-16cb-45b4-a8a4-bfdc41aa77f4)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
4. Boot the app via `dev up` (now triggers watch), or `dev watch`
5. Log in to the app at http://localhost:8080
6. Save a front-end file and check that the front-end reloads.
7. Save a back-end file and check that the back-end reloads.
