### PR TITLE
Post Demo Fixups

### DIFF
--- a/api/src/serializers/information-sharing-agreements/show-serializer.ts
+++ b/api/src/serializers/information-sharing-agreements/show-serializer.ts
@@ -1,5 +1,7 @@
 import { pick } from "lodash"
 
+import { formatDate } from "@/utils/formatters"
+
 import { InformationSharingAgreement } from "@/models"
 import BaseSerializer from "@/serializers/base-serializer"
 
@@ -13,14 +15,19 @@ export type AgreementShowView = Pick<
   | "receivingGroupContactId"
   | "title"
   | "description"
-  | "startDate"
-  | "endDate"
   | "createdAt"
   | "updatedAt"
->
+> & {
+  startDate: string
+  endDate: string
+}
 
 export class ShowSerializer extends BaseSerializer<InformationSharingAgreement> {
   perform(): AgreementShowView {
+    const { startDate, endDate } = this.record
+    const formattedStartDate = formatDate(startDate)
+    const formattedEndDate = formatDate(endDate)
+
     return {
       ...pick(this.record, [
         "id",
@@ -31,11 +38,11 @@ export class ShowSerializer extends BaseSerializer<InformationSharingAgreement> 
         "receivingGroupContactId",
         "title",
         "description",
-        "startDate",
-        "endDate",
         "createdAt",
         "updatedAt",
       ]),
+      startDate: formattedStartDate,
+      endDate: formattedEndDate,
     }
   }
 }

--- a/api/src/utils/formatters/format-date.ts
+++ b/api/src/utils/formatters/format-date.ts
@@ -1,0 +1,20 @@
+import { isEmpty, isNil } from "lodash"
+import { DateTime, type LocaleOptions } from "luxon"
+
+export function formatDate(
+  date: Date | string | null | undefined,
+  fmt: string = "yyyy-MM-dd",
+  opts?: LocaleOptions
+): string {
+  if (date instanceof Date) {
+    return DateTime.fromJSDate(date).toFormat(fmt, opts)
+  }
+
+  if (isNil(date) || isEmpty(date)) {
+    return ""
+  }
+
+  return DateTime.fromISO(date).toFormat(fmt, opts)
+}
+
+export default formatDate

--- a/api/src/utils/formatters/index.ts
+++ b/api/src/utils/formatters/index.ts
@@ -1,0 +1,1 @@
+export { formatDate } from "./format-date"

--- a/api/tests/services/users/ensure-from-auth0-token-service.test.ts
+++ b/api/tests/services/users/ensure-from-auth0-token-service.test.ts
@@ -50,22 +50,18 @@ describe("api/src/services/users/ensure-from-auth0-token-service.ts", () => {
         }
         mockedAuth0Integration.getUserInfo.mockResolvedValue(getUserInfoResult)
 
-
         // Assert
         expect.assertions(2)
         let result
-        await expect(
-          async () => {
-            // Act
-            result = await EnsureFromAuth0TokenService.perform(token)
-            return result
-          }
-        ).toChange(() => User.count(), { from: 0, to: 1 })
-        expect(result).to.be.instanceOf(User).with.property("authSubject", auth0Subject)
+        await expect(async () => {
+          // Act
+          result = await EnsureFromAuth0TokenService.perform(token)
+          return result
+        }).toChange(() => User.count(), { from: 0, to: 1 })
+        expect(result).to.be.instanceOf(User).with.property("auth0Subject", auth0Subject)
       })
 
       test("when user with Auth0 subject, matching email returned by Auth0 integration, exists in database, updates and returns user", async () => {
-        // Arrange
         // Arrange
         const token = "Auth0AccessToken"
         const auth0Subject = "auth0|74df9b33217f9d4c8fefcc8b"
@@ -87,7 +83,7 @@ describe("api/src/services/users/ensure-from-auth0-token-service.ts", () => {
         // Assert
         expect(result).to.be.instanceOf(User).and.to.include({
           id: user.id,
-          authSubject: auth0Subject,
+          auth0Subject,
           email: user.email,
         })
       })

--- a/web/src/components/common/StringDateInput.vue
+++ b/web/src/components/common/StringDateInput.vue
@@ -49,6 +49,9 @@ watch(
   }
 )
 
+/**
+ * NOTE: v-date-input returns Date | string, rather than just "string" like it's types imply.
+ */
 function emitStringResult(value: unknown) {
   if (value instanceof Date) {
     const dateTime = DateTime.fromJSDate(value)

--- a/web/src/components/common/StringDateInput.vue
+++ b/web/src/components/common/StringDateInput.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-date-input
+    v-bind="$attrs"
+    v-model="formattedDate"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { DateTime } from "luxon"
+import { isNil } from "lodash"
+
+/**
+ * A date input accepts and returns a string.
+ */
+const props = withDefaults(
+  defineProps<{
+    modelValue: string | null | undefined
+    returnFormat?: string
+  }>(),
+  {
+    returnFormat: "yyyy-MM-dd",
+  }
+)
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string]
+}>()
+
+const formattedDate = computed({
+  get() {
+    if (isNil(props.modelValue)) return undefined
+
+    const date = DateTime.fromISO(props.modelValue).toJSDate()
+    return date
+  },
+  set(value) {
+    if (value instanceof Date) {
+      const stringValue = DateTime.fromJSDate(value).toFormat(props.returnFormat)
+      if (isNil(stringValue)) {
+        emit("update:modelValue", "")
+        return ""
+      }
+
+      emit("update:modelValue", stringValue)
+      return stringValue
+    }
+
+    emit("update:modelValue", "")
+    return ""
+  },
+})
+</script>

--- a/web/src/components/common/StringDateInput.vue
+++ b/web/src/components/common/StringDateInput.vue
@@ -1,7 +1,8 @@
 <template>
   <v-date-input
-    :model-value="date"
-    @update:model-value="updateDateAndEmit"
+    v-model="date"
+    v-bind="$attrs"
+    @update:model-value="emitStringResult"
   />
 </template>
 
@@ -34,31 +35,32 @@ watch(
   (newValue) => {
     if (isNil(newValue)) {
       date.value = null
-      return
+    } else {
+      const dateTime = DateTime.fromISO(newValue)
+      if (dateTime.isValid) {
+        date.value = dateTime.toJSDate()
+      } else {
+        date.value = null
+      }
     }
-
-    const newDate = DateTime.fromISO(newValue).toJSDate()
-    date.value = newDate
+  },
+  {
+    immediate: true,
   }
 )
 
-function updateDateAndEmit(value: unknown) {
+function emitStringResult(value: unknown) {
   if (value instanceof Date) {
-    date.value = value
-
-    const stringValue = DateTime.fromJSDate(value).toFormat(props.returnFormat)
-    if (isNil(stringValue)) {
+    const dateTime = DateTime.fromJSDate(value)
+    if (dateTime.isValid) {
+      const stringValue = dateTime.toFormat(props.returnFormat)
+      emit("update:modelValue", stringValue)
+    } else {
       emit("update:modelValue", null)
-      return
     }
-
-    emit("update:modelValue", stringValue)
-    return stringValue
   } else if (typeof value === "string") {
-    date.value = DateTime.fromISO(value).toJSDate()
     emit("update:modelValue", value)
   } else {
-    date.value = null
     emit("update:modelValue", null)
   }
 }

--- a/web/src/components/information-sharing-agreements/InformationSharingAgreementCreateForm.vue
+++ b/web/src/components/information-sharing-agreements/InformationSharingAgreementCreateForm.vue
@@ -85,7 +85,7 @@
             md="6"
           >
             <!-- TODO: consider using a v-date-input range type? -->
-            <v-date-input
+            <StringDateInput
               v-model="informationSharingAgreementAttributes.startDate"
               label="Start Date *"
               :rules="[required]"
@@ -97,7 +97,7 @@
             cols="12"
             md="6"
           >
-            <v-date-input
+            <StringDateInput
               v-model="informationSharingAgreementAttributes.endDate"
               label="End Date *"
               :rules="[required]"
@@ -150,6 +150,7 @@ import informationSharingAgreementsApi, {
 import useCurrentUser from "@/use/use-current-user"
 import useSnack from "@/use/use-snack"
 
+import StringDateInput from "@/components/common/StringDateInput.vue"
 import GroupSearchableAutocomplete from "@/components/groups/GroupSearchableAutocomplete.vue"
 import UserSearchableAutocomplete from "@/components/users/UserSearchableAutocomplete.vue"
 

--- a/web/src/components/information-sharing-agreements/InformationSharingAgreementEditForm.vue
+++ b/web/src/components/information-sharing-agreements/InformationSharingAgreementEditForm.vue
@@ -69,7 +69,7 @@
             md="6"
           >
             <!-- TODO: consider using a v-date-input range type? -->
-            <v-date-input
+            <StringDateInput
               v-model="informationSharingAgreement.startDate"
               label="Start Date *"
               :rules="[required]"
@@ -81,7 +81,7 @@
             cols="12"
             md="6"
           >
-            <v-date-input
+            <StringDateInput
               v-model="informationSharingAgreement.endDate"
               label="End Date *"
               :rules="[required]"
@@ -127,6 +127,7 @@ import { required } from "@/utils/validators"
 import useInformationSharingAgreement from "@/use/use-information-sharing-agreement"
 import useSnack from "@/use/use-snack"
 
+import StringDateInput from "@/components/common/StringDateInput.vue"
 import GroupChip from "@/components/groups/GroupChip.vue"
 import UserSearchableAutocomplete from "@/components/users/UserSearchableAutocomplete.vue"
 

--- a/web/src/plugins/vuetify-plugin.ts
+++ b/web/src/plugins/vuetify-plugin.ts
@@ -82,6 +82,7 @@ export default createVuetify({
       variant: "outlined",
       density: "comfortable",
       color: "primary",
+      hideActions: true,
       hideDetails: "auto",
       bgColor: "#fff",
       prependIcon: "",

--- a/web/src/utils/validators/required.ts
+++ b/web/src/utils/validators/required.ts
@@ -5,10 +5,9 @@ export function required(v: unknown): boolean | string {
     return "This field is required"
   }
 
-  if (
-    v instanceof Date &&
-    isNaN(v.getTime())
-  ) {
+  if (v instanceof Date) {
+    if (!isNaN(v.getTime())) return true
+
     return "This field is required"
   }
 

--- a/web/src/utils/validators/required.ts
+++ b/web/src/utils/validators/required.ts
@@ -5,6 +5,13 @@ export function required(v: unknown): boolean | string {
     return "This field is required"
   }
 
+  if (
+    v instanceof Date &&
+    isNaN(v.getTime())
+  ) {
+    return "This field is required"
+  }
+
   if ((isArray(v) || isString(v) || isObject(v)) && isEmpty(v)) {
     return "This field is required"
   }


### PR DESCRIPTION
# Context

Information sharing agreement edit form start/end dates where crashing in the UI.

# Implementation

1. Serialize back-end information sharing agreement start/end dates so they are returned in correct format.
2. Build "better" date input UI component so that it can handle string based dates instead of only js Date format.
    Avoids need to do this for every date type input value:
    ```ts
    const adapter = useDate()
    
    const startDate = computed({
      get() {
        if (isNil(informationSharingAgreement.value)) return null
    
       // note parseISO doesn't work like luxon's parseISO and fails when given an actual ISO formatted string.
        const date = adapter.parseISO(informationSharingAgreement.value.startDate)
        return date
      },
      set(value) {
        if (isNil(informationSharingAgreement.value)) return
        if (isNil(value)) return
    
        const stringValue = adapter.toISO(value)
        informationSharingAgreement.value.startDate = stringValue
      },
    })
    ```
3. Update base v-date-input config so it closes when you select a value.

## Concerns

It looks like Sequelize converts all "date" string values in UTC, but doesn't convert them back out?
I'm pretty sure this won't be a problem, but if we start getting values that are 1 day off after 5pm or something then we should figure out a pattern to deal with it.
e.g. a custom getter that returns the data as a string right from the model.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
4. Boot the app via `dev up`
5. Log in to the app at http://localhost:8080 as system admin.
6. Go to Administration via the left side nav.
7. Select information sharing agreements.
8. Create a new information sharing agreement.
9. Click on it n the list.
10. Click the "edit" call-to-action button to edit the agreement.
11. Check that you can update the start/end dates and that they persist correctly after saving.
