### PR TITLE
TK-19: Add Archive Service Image to Docker Publish Workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@ docs
 /now.*
 /*.now.*
 **/now.*
+
+.secrets

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,6 +43,16 @@ jobs:
             RELEASE_TAG=${{ steps.generate_release_tag.outputs.next_release_tag }}
             GIT_COMMIT_HASH=${{ steps.git_commit_hash.outputs.commit_hash }}
 
+      - name: Build and push archiver Docker image
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: ./archiver
+          push: true
+          tags: ${{ secrets.AZURECR_URL }}/traditional-knowledge-archiver:${{ steps.generate_release_tag.outputs.next_release_tag }} , ${{ secrets.AZURECR_URL }}/traditional-knowledge-archiver:latest
+          build-args: |
+            RELEASE_TAG=${{ steps.generate_release_tag.outputs.next_release_tag }}
+            GIT_COMMIT_HASH=${{ steps.git_commit_hash.outputs.commit_hash }}
+
       - name: Create release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,6 +52,8 @@ jobs:
           build-args: |
             RELEASE_TAG=${{ steps.generate_release_tag.outputs.next_release_tag }}
             GIT_COMMIT_HASH=${{ steps.git_commit_hash.outputs.commit_hash }}
+            SSL_PRIVATE_ICEFOG_PEM=${{ secrets.SSL_PRIVATE_ICEFOG_PEM }}
+            SSL_CERT_FULLCHAIN_PEM=${{ secrets.SSL_CERT_FULLCHAIN_PEM }}
 
       - name: Create release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/build-push-action@v5.3.0
         with:
           context: .
-          push: true
+          push: ${{ env.DOCKER_PUSH || 'true' }}
           tags: ${{ secrets.AZURECR_URL }}/traditional-knowledge:${{ steps.generate_release_tag.outputs.next_release_tag }} , ${{ secrets.AZURECR_URL }}/traditional-knowledge:latest
           build-args: |
             RELEASE_TAG=${{ steps.generate_release_tag.outputs.next_release_tag }}
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v5.3.0
         with:
           context: ./archiver
-          push: true
+          push: ${{ env.DOCKER_PUSH || 'true' }}
           tags: ${{ secrets.AZURECR_URL }}/traditional-knowledge-archiver:${{ steps.generate_release_tag.outputs.next_release_tag }} , ${{ secrets.AZURECR_URL }}/traditional-knowledge-archiver:latest
           build-args: |
             RELEASE_TAG=${{ steps.generate_release_tag.outputs.next_release_tag }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,9 +6,6 @@ on:
     # Publish semver tags as releases.
     tags: ["v*.*.*", "v*.*.*.*"]
 
-env:
-  REGISTRY: ghcr.io
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: Log into registry ${{ secrets.AZURECR_URL }}
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.AZURECR_URL }}
@@ -36,7 +33,7 @@ jobs:
         id: git_commit_hash
         run: echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build and push web Docker image
+      - name: Build and push app Docker image
         uses: docker/build-push-action@v5.3.0
         with:
           context: .

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ db/data
 note.md
 now.md
 now.sql
+
+# GitHub Actions
+.secrets

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,13 @@ ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH}
 ENV TZ=UTC
 
 ENV NODE_ENV=production
-USER node
 
+# Updating npm did not fix this issue, though it might at a future date.
+# Fix Your cache folder contains root-owned files, due to a bug in previous versions of npm which has since been addressed.
+RUN mkdir -p /home/node/.npm
+RUN chown -R node:node "/home/node/.npm"
+
+USER node
 WORKDIR /home/node/app
 RUN chown -R node:node /home/node/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ COPY api ./
 
 RUN npm run build
 
+# Create production seeds directory if empty
+RUN mkdir -p dist/db/seeds/production
+
 # Copy html files, remove once we are using Vite for build process
 COPY api/src/templates ./dist/templates
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Files:
    DB_DATABASE=traditional_knowledge_production
 
    VITE_API_BASE_URL="http://localhost:8080"
-   VITE_AUTH0_CLIENT_ID="mNqPwPZ5M1VXkEH6e8OgEaxmmWfxecwo"
+   VITE_AUTH0_CLIENT_ID="fsWyrDohhHtojdOpOFnAYtFMxwAMHUEF"
    VITE_AUTH0_AUDIENCE="testing"
    VITE_AUTH0_DOMAIN="https://dev-0tc6bn14.eu.auth0.com"
 

--- a/README.md
+++ b/README.md
@@ -360,3 +360,33 @@ Files:
 4. Go to http://localhost:3000/ and log in.
 
 5. Navigate around the app and do some stuff and see if it works.
+
+## Testing GitHub Publish Locally
+
+- https://nektosact.com/installation/gh.html
+- https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+
+1. Install GitHub CLI, via:
+   ```sh
+   sudo apt install gh
+   ```
+   See https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+   NOTE: `snap` version of `gh` has permission limits, and will not work correctly, so use the `apt` version instead.
+2. Install GitHub publish library via:
+   ```sh
+   gh extension install https://github.com/nektos/gh-act
+   ```
+   See https://nektosact.com/installation/gh.html
+3. Generate secrets file via:
+   ```sh
+   ./bin/build-github-act-secrets-file.sh
+   ```
+4. Run publish action via:
+   ```sh
+   gh act push \
+      -P ubuntu-latest=-self-hosted \
+      --job build \
+      --env DOCKER_PUSH=false \
+      --secret-file .secrets
+   ```
+   Wait a long time, this will be very slow and not show much progress.

--- a/archiver/Dockerfile
+++ b/archiver/Dockerfile
@@ -1,0 +1,85 @@
+# Stage 0 - base node customizations
+FROM node:20.18.0-alpine3.19 AS base-node
+
+RUN npm install -g npm@10.9.0
+
+# Stage 1 - archiver build - requires development environment because typescript
+FROM base-node AS archiver-build-stage
+
+ENV NODE_ENV=development
+
+WORKDIR /usr/src/archiver
+
+COPY ./package*.json ./
+COPY ./tsconfig*.json ./
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+
+# Stage 3 - production setup
+FROM base-node
+
+ARG RELEASE_TAG
+ARG GIT_COMMIT_HASH
+
+ENV RELEASE_TAG=${RELEASE_TAG}
+ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH}
+
+# Install dependencies
+RUN apk add --no-cache \
+  openjdk21 \
+  libreoffice \
+  curl
+
+# Font configuration (https://stackoverflow.com/questions/56937689/how-to-install-fonts-in-docker)
+WORKDIR /root/fonts
+
+RUN apk add --no-cache msttcorefonts-installer fontconfig
+RUN update-ms-fonts
+RUN apk add ttf-freefont font-terminus font-inconsolata font-dejavu font-noto font-noto-cjk font-awesome font-noto-extra
+
+# Google fonts
+RUN wget https://github.com/google/fonts/archive/main.tar.gz -O gf.tar.gz --no-check-certificate
+RUN tar -xf gf.tar.gz
+RUN mkdir -p /usr/share/fonts/truetype/google-fonts
+RUN find $PWD/fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1
+RUN rm -f gf.tar.gz
+RUN fc-cache -f && rm -rf /var/cache/*
+
+# PDF signer
+WORKDIR /var/lib
+
+RUN curl --location --output open-pdf-sign.jar https://github.com/open-pdf-sign/open-pdf-sign/releases/latest/download/open-pdf-sign.jar
+
+ENV JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
+ENV PATH="$JAVA_HOME/bin:$PATH"
+
+# Persists TZ=UTC effect after container build and into container run
+# Ensures dates/times are consistently formated as UTC
+# Conversion to local time should happen in the UI
+ENV TZ=UTC
+
+ENV NODE_ENV=production
+USER node
+
+WORKDIR /home/node/app
+RUN chown -R node:node /home/node/app
+
+COPY --from=archiver-build-stage --chown=node:node /usr/src/archiver/package*.json ./
+RUN npm install && npm cache clean --force --loglevel=error
+
+COPY --from=archiver-build-stage --chown=node:node /usr/src/archiver/dist ./dist/
+
+RUN echo "RELEASE_TAG=${RELEASE_TAG}" >> VERSION
+RUN echo "GIT_COMMIT_HASH=${GIT_COMMIT_HASH}" >> VERSION
+
+EXPOSE 3000
+
+COPY --from=archiver-build-stage --chown=node:node /usr/src/archiver/bin/boot-app.sh ./bin/
+
+RUN chmod +x ./bin/boot-app.sh
+
+CMD ["./bin/boot-app.sh"]

--- a/archiver/Dockerfile
+++ b/archiver/Dockerfile
@@ -61,6 +61,13 @@ ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH}
 ENV JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
 ENV PATH="$JAVA_HOME/bin:$PATH"
 
+# Persists TZ=UTC effect after container build and into container run
+# Ensures dates/times are consistently formated as UTC
+# Conversion to local time should happen in the UI
+ENV TZ=UTC
+
+ENV NODE_ENV=production
+
 # Create private key directory and set permissions
 RUN mkdir -p /etc/ssl/private && \
     printf '%s\n' "$SSL_PRIVATE_ICEFOG_PEM" > /etc/ssl/private/icefog.pem && \
@@ -75,14 +82,12 @@ RUN mkdir -p /etc/ssl/certs && \
     chmod 755 /etc/ssl/certs && \
     chmod 444 /etc/ssl/certs/fullchain.pem
 
-# Persists TZ=UTC effect after container build and into container run
-# Ensures dates/times are consistently formated as UTC
-# Conversion to local time should happen in the UI
-ENV TZ=UTC
+# Updating npm did not fix this issue, though it might at a future date.
+# Fix Your cache folder contains root-owned files, due to a bug in previous versions of npm which has since been addressed.
+RUN mkdir -p /home/node/.npm
+RUN chown -R node:node "/home/node/.npm"
 
-ENV NODE_ENV=production
 USER node
-
 WORKDIR /home/node/app
 RUN chown -R node:node /home/node/app
 

--- a/archiver/Dockerfile
+++ b/archiver/Dockerfile
@@ -18,15 +18,8 @@ COPY . .
 
 RUN npm run build
 
-
-# Stage 3 - production setup
-FROM base-node
-
-ARG RELEASE_TAG
-ARG GIT_COMMIT_HASH
-
-ENV RELEASE_TAG=${RELEASE_TAG}
-ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH}
+# Stage 2 - production dependencies
+FROM base-node AS production-dependencies-stage
 
 # Install dependencies
 RUN apk add --no-cache \
@@ -53,6 +46,15 @@ RUN fc-cache -f && rm -rf /var/cache/*
 WORKDIR /var/lib
 
 RUN curl --location --output open-pdf-sign.jar https://github.com/open-pdf-sign/open-pdf-sign/releases/latest/download/open-pdf-sign.jar
+
+# Stage 3 - production setup
+FROM production-dependencies-stage
+
+ARG RELEASE_TAG
+ARG GIT_COMMIT_HASH
+
+ENV RELEASE_TAG=${RELEASE_TAG}
+ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH}
 
 ENV JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
 ENV PATH="$JAVA_HOME/bin:$PATH"

--- a/archiver/Dockerfile
+++ b/archiver/Dockerfile
@@ -52,12 +52,26 @@ FROM production-dependencies-stage
 
 ARG RELEASE_TAG
 ARG GIT_COMMIT_HASH
+ARG SSL_PRIVATE_ICEFOG_PEM
+ARG SSL_CERT_FULLCHAIN_PEM
 
 ENV RELEASE_TAG=${RELEASE_TAG}
 ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH}
 
 ENV JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
 ENV PATH="$JAVA_HOME/bin:$PATH"
+
+# Create private key directory and set permissions
+RUN mkdir -p /etc/ssl/private && chmod 700 /etc/ssl/private && \
+    printf '%s\n' "$SSL_PRIVATE_ICEFOG_PEM" > /etc/ssl/private/icefog.pem && \
+    chmod 400 /etc/ssl/private/icefog.pem && \
+    chown root:root /etc/ssl/private/icefog.pem
+
+# Create full chain directory and set permissions
+RUN mkdir -p /etc/ssl/certs && chmod 755 /etc/ssl/certs && \
+    printf '%s\n' "$SSL_CERT_FULLCHAIN_PEM" > /etc/ssl/certs/fullchain.pem && \
+    chmod 444 /etc/ssl/certs/fullchain.pem && \
+    chown root:root /etc/ssl/certs/fullchain.pem
 
 # Persists TZ=UTC effect after container build and into container run
 # Ensures dates/times are consistently formated as UTC
@@ -66,12 +80,6 @@ ENV TZ=UTC
 
 ENV NODE_ENV=production
 USER node
-
-# Load SSL certificates and set permissions
-# Copy the private key (readable by root only)
-COPY --chown=root:root --chmod=0400 certs/icefog.pem /etc/ssl/private/icefog.pem
-# Copy the full chain (read-only for everyone is fine)
-COPY --chown=root:root --chmod=0444 certs/fullchain.pem /etc/ssl/certs/fullchain.pem
 
 WORKDIR /home/node/app
 RUN chown -R node:node /home/node/app

--- a/archiver/Dockerfile
+++ b/archiver/Dockerfile
@@ -65,6 +65,12 @@ ENV TZ=UTC
 ENV NODE_ENV=production
 USER node
 
+# Load SSL certificates and set permissions
+# Copy the private key (readable by root only)
+COPY --chown=root:root --chmod=0400 certs/icefog.pem /etc/ssl/private/icefog.pem
+# Copy the full chain (read-only for everyone is fine)
+COPY --chown=root:root --chmod=0444 certs/fullchain.pem /etc/ssl/certs/fullchain.pem
+
 WORKDIR /home/node/app
 RUN chown -R node:node /home/node/app
 

--- a/archiver/Dockerfile
+++ b/archiver/Dockerfile
@@ -62,16 +62,18 @@ ENV JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
 ENV PATH="$JAVA_HOME/bin:$PATH"
 
 # Create private key directory and set permissions
-RUN mkdir -p /etc/ssl/private && chmod 700 /etc/ssl/private && \
+RUN mkdir -p /etc/ssl/private && \
     printf '%s\n' "$SSL_PRIVATE_ICEFOG_PEM" > /etc/ssl/private/icefog.pem && \
-    chmod 400 /etc/ssl/private/icefog.pem && \
-    chown root:root /etc/ssl/private/icefog.pem
+    chown root:node /etc/ssl/private /etc/ssl/private/icefog.pem && \
+    chmod 750 /etc/ssl/private && \
+    chmod 440 /etc/ssl/private/icefog.pem
 
 # Create full chain directory and set permissions
-RUN mkdir -p /etc/ssl/certs && chmod 755 /etc/ssl/certs && \
+RUN mkdir -p /etc/ssl/certs && \
     printf '%s\n' "$SSL_CERT_FULLCHAIN_PEM" > /etc/ssl/certs/fullchain.pem && \
-    chmod 444 /etc/ssl/certs/fullchain.pem && \
-    chown root:root /etc/ssl/certs/fullchain.pem
+    chown root:node /etc/ssl/certs /etc/ssl/certs/fullchain.pem && \
+    chmod 755 /etc/ssl/certs && \
+    chmod 444 /etc/ssl/certs/fullchain.pem
 
 # Persists TZ=UTC effect after container build and into container run
 # Ensures dates/times are consistently formated as UTC

--- a/archiver/README.md
+++ b/archiver/README.md
@@ -3,8 +3,10 @@
 ## Building Production Image Locally
 
 1. From the top level of the repository, run the docker-compose.yml file:
-    ```bash
-    docker compose build \
-      --build-arg RELEASE_TAG=$(date +%Y.%m.%d) \
-      --build-arg GIT_COMMIT_HASH=$(git rev-parse HEAD)
-    ```
+   ```bash
+   docker compose build \
+     --build-arg RELEASE_TAG="$(date +%Y.%m.%d)" \
+     --build-arg GIT_COMMIT_HASH="$(git rev-parse HEAD)" \
+     --build-arg SSL_PRIVATE_ICEFOG_PEM="$(cat ./archiver/certs/icefog.pem)" \
+     --build-arg SSL_CERT_FULLCHAIN_PEM="$(cat ./archiver/certs/fullchain.pem)"
+   ```

--- a/archiver/README.md
+++ b/archiver/README.md
@@ -1,0 +1,10 @@
+# Archiver Service
+
+## Building Production Image Locally
+
+1. From the top level of the repository, run the docker-compose.yml file:
+    ```bash
+    docker compose build \
+      --build-arg RELEASE_TAG=$(date +%Y.%m.%d) \
+      --build-arg GIT_COMMIT_HASH=$(git rev-parse HEAD)
+    ```

--- a/archiver/bin/boot-app.sh
+++ b/archiver/bin/boot-app.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-npm run start
+if [ "$NODE_ENV" = "production" ]; then
+	node ./dist/server.js
+else
+	npm run start
+fi

--- a/archiver/bin/boot-app.sh
+++ b/archiver/bin/boot-app.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+if [ "$RUN_SCHEDULER" = "true" ]; then
+	echo "Running scheduler"
+	if [ "$NODE_ENV" = "production" ]; then
+		node ./dist/scheduler.js
+	else
+		npm run start:scheduler
+	fi
+	exit 0
+fi
+
 if [ "$NODE_ENV" = "production" ]; then
 	node ./dist/server.js
 else

--- a/archiver/src/utils/pdf-signer.ts
+++ b/archiver/src/utils/pdf-signer.ts
@@ -19,8 +19,8 @@ export async function signPDFWithPAdES(
   return new Promise((resolve, reject) => {
     exec(cmd, { encoding: "buffer" }, (error, stderr) => {
       if (error) {
-        logger.error("open-pdf-sign error:", stderr.toString())
-        reject(new Error(`open-pdf-sign error: ${stderr.toString()}`))
+        logger.error(`open-pdf-sign error: ${error} -> ${stderr}`, { error, stderr })
+        reject(new Error(`open-pdf-sign error: ${stderr}`))
         return
       }
       resolve()

--- a/bin/build-github-act-secrets-file.sh
+++ b/bin/build-github-act-secrets-file.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# gen-secrets.sh – create a .secrets file for nektos/act
+
+set -euo pipefail
+
+SCRIPT_DIRECTORY=$(dirname "$(realpath "$0")")
+APP_DIRECTORY=$(dirname "$SCRIPT_DIRECTORY")
+CERT_DIR="$APP_DIRECTORY/archiver/certs"
+
+# ---- sanity checks ---------------------------------------------------------
+[[ -f "$CERT_DIR/fullchain.pem" ]] || { echo "Error: $CERT_DIR/fullchain.pem missing"; exit 1; }
+[[ -f "$CERT_DIR/icefog.pem"    ]] || { echo "Error: $CERT_DIR/icefog.pem    missing"; exit 1; }
+
+# ---- helper for interactive secrets ---------------------------------------
+ask() {                         # ask VAR "Prompt" [silent]
+  local var=$1 prompt=$2 silent=${3:-no}
+  if [[ -z "${!var:-}" ]]; then
+    if [[ $silent == yes ]]; then
+      read -rsp "$prompt: " val && echo
+    else
+      read  -rp "$prompt: " val
+    fi
+    export "$var"="$val"
+  fi
+}
+
+# ---- collect credentials ---------------------------------------------------
+ask AZURECR_URL      "Azure Container Registry URL (e.g. myregistry.azurecr.io)"
+ask AZURECR_USERNAME "ACR service-principal / robot user"
+ask AZURECR_PASSWORD "ACR password" yes
+
+# ---- encode PEMs as single-line strings ------------------------------------
+encode() { awk '{printf "%s\\n",$0}' "$1"; }        # replace LF → \n
+fullchain=$(encode "$CERT_DIR/fullchain.pem")
+icefog=$(encode "$CERT_DIR/icefog.pem")
+
+# ---- write .secrets --------------------------------------------------------
+cat > "$APP_DIRECTORY/.secrets" <<EOF
+AZURECR_URL=$AZURECR_URL
+AZURECR_USERNAME=$AZURECR_USERNAME
+AZURECR_PASSWORD=$AZURECR_PASSWORD
+SSL_CERT_FULLCHAIN_PEM="$fullchain"
+SSL_PRIVATE_ICEFOG_PEM="$icefog"
+GITHUB_TOKEN=$(gh auth token)
+EOF
+
+echo "Success: Wrote .secrets
+Run:
+  gh act push \
+      -P ubuntu-latest=-self-hosted \
+      --job build \
+      --env DOCKER_PUSH=false \
+      --secret-file .secrets
+"

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -28,7 +28,7 @@ x-default-environment: &default-environment
   TIMESTAMP_SERVER: "http://timestamp.digicert.com"
   SSL_FULL_CHAIN_PATH: "/etc/ssl/certs/fullchain.pem"
   SSL_CERT_KEY_PATH: "/etc/ssl/private/icefog.pem"
-  BLOB_CONTAINER: "traditional-knowledge-development"
+  BLOB_CONTAINER: "the-vault"
 
 x-shared-watch:
   - &gitignore-sync

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -14,7 +14,7 @@ x-default-environment: &default-environment
   FRONTEND_URL: "http://localhost:8080"
   VITE_APPLICATION_NAME: "Traditional Knowledge"
   VITE_API_BASE_URL: "http://localhost:3000"
-  VITE_AUTH0_CLIENT_ID: "mNqPwPZ5M1VXkEH6e8OgEaxmmWfxecwo"
+  VITE_AUTH0_CLIENT_ID: "fsWyrDohhHtojdOpOFnAYtFMxwAMHUEF"
   VITE_AUTH0_AUDIENCE: "testing"
   VITE_AUTH0_DOMAIN: "https://dev-0tc6bn14.eu.auth0.com"
   RELEASE_TAG: "${RELEASE_TAG:-development}"

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -148,8 +148,7 @@ services:
   #     - ./web:/usr/src/web
 
   cache:
-    image: bitnami/redis:7.2.4
-    user: root
+    image: bitnami/redis:8.0.2
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -170,8 +170,7 @@ services:
       - db_data:/var/opt/mssql/data
 
   mail:
-    image: maildev/maildev
-    user: root
+    image: maildev/maildev:2.2.1
     ports:
       - "1080:1080" # Web UI
       - "1025:1025" # SMTP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,7 @@ services:
       - "1025:1025" # SMTP
 
   cache:
-    image: bitnami/redis:7.2.4
-    user: root
+    image: bitnami/redis:8.0.2
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     ports:
       - "${ARCHIVER_HOST_PORT:-5000}:${ARCHIVER_HOST_PORT:-5000}"
     volumes:
-      - ./.env:/home/node/app/.env.production
+      - ./.env:/home/node/archiver/.env.production
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,5 +48,13 @@ services:
       - "1080:1080" # Web UI
       - "1025:1025" # SMTP
 
+  cache:
+    image: bitnami/redis:7.2.4
+    user: root
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - "6379:6379"
+
 volumes:
   db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,20 @@ services:
     depends_on:
       - db
 
+  archiver:
+    build: ./archiver
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production
+    ports:
+      - "${ARCHIVER_HOST_PORT:-5000}:${ARCHIVER_HOST_PORT:-5000}"
+    volumes:
+      - ./.env:/home/node/app/.env.production
+    depends_on:
+      - db
+
   db:
     image: mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04
     user: root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - db_data:/var/opt/mssql/data
 
   mail:
-    image: maildev/maildev
+    image: maildev/maildev:2.2.1
     ports:
       - "1080:1080" # Web UI
       - "1025:1025" # SMTP

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -4,7 +4,7 @@ export const ENVIRONMENT = import.meta.env.MODE
 
 const prodConfig = {
   domain: "https://yukon.eu.auth0.com",
-  clientId: "mNqPwPZ5M1VXkEH6e8OgEaxmmWfxecwo",
+  clientId: "fsWyrDohhHtojdOpOFnAYtFMxwAMHUEF",
   audience: "generic-production",
   apiBaseUrl: "",
   applicationName: "Traditional Knowledge",
@@ -28,7 +28,7 @@ const devConfig = {
 
 const localProductionConfig = {
   domain: "https://dev-0tc6bn14.eu.auth0.com",
-  clientId: "mNqPwPZ5M1VXkEH6e8OgEaxmmWfxecwo",
+  clientId: "fsWyrDohhHtojdOpOFnAYtFMxwAMHUEF",
   audience: "testing",
   apiBaseUrl: "http://localhost:8080",
   applicationName: "Traditional Knowledge",


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/TK-19

# Context

We need the ability to run a separate container for running PDF conversion jobs.
Currently this is implemented as the “archiver” service, and we need a build pipeline for the Archiver image.

# Implementation

1. Add new build and publish step for Archiver service to GitHub publish action.
2. Store cert file (.pem) in GitHub project secrets, and bake them into the published image at build time.
3. Add archiver service to main docker compose yaml file on port 5000 for easier build testing
4. Add reame for building archiver image. Image is built using service local Dockerfile.

## Concerns

1. It is a bit of security risk baking the certs into the image, as anyone with access to the image will have access to the certs. The alternative is to load the certs during app boot from an intializer via an ENV variable rather than baking them into the image.
2. I'm still investigating running GitHub publish action locally.

# Testing Instructions

1. From the top level of the repository, run the docker-compose.yml file:
   ```bash
   docker compose build \
     --build-arg RELEASE_TAG="$(date +%Y.%m.%d)" \
     --build-arg GIT_COMMIT_HASH="$(git rev-parse HEAD)" \
     --build-arg SSL_PRIVATE_ICEFOG_PEM="$(cat ./archiver/certs/icefog.pem)" \
     --build-arg SSL_CERT_FULLCHAIN_PEM="$(cat ./archiver/certs/fullchain.pem)"
   ```
3. Boot the app via `docker compose up`
4. Test built image by going to the logging in to the production built app at http://localhost:8080.
5. Create a new archive item from the dashboard option and add a .docx files as an attachment.
6. Check that the item uploads correctly, and is correctly converted to a PDF.

## Testing GitHub Publish Locally

- https://nektosact.com/installation/gh.html
- https://github.com/cli/cli/blob/trunk/docs/install_linux.md

1. Install GitHub CLI, via:
   ```sh
   sudo apt install gh
   ```
   See https://github.com/cli/cli/blob/trunk/docs/install_linux.md
   NOTE: `snap` version of `gh` has permission limits, and will not work correctly, so use the `apt` version instead.
2. Install GitHub publish library via:
   ```sh
   gh extension install https://github.com/nektos/gh-act
   ```
   See https://nektosact.com/installation/gh.html
3. Generate secrets file via:
   ```sh
   ./bin/build-github-act-secrets-file.sh
   ```
4. Run publish action via:
   ```sh
   gh act push \
      -P ubuntu-latest=-self-hosted \
      --job build \
      --env DOCKER_PUSH=false \
      --secret-file .secrets
   ```
   Wait a long time, this will be very slow and not show much progress.
   NOTE: you can push the image as well by leaving out `--env DOCKER_PUSH=false`
    
