### PR TITLE
Populate key `access_level_department_restriction` in CA template

### DIFF
--- a/api/src/serializers/information-sharing-agreements/generate-confidentiality-acknowledgement/create-serializer.ts
+++ b/api/src/serializers/information-sharing-agreements/generate-confidentiality-acknowledgement/create-serializer.ts
@@ -36,6 +36,7 @@ export type InformationSharingAgreementAsConfidentialityAcknowledgement = {
   "access_level.is_internal": boolean
   "access_level.is_protected_and_limited": boolean
   "access_level.is_confidential_and_restricted": boolean
+  access_level_department_restriction: string
   department_branch_unit_hierarchy: string
   has_additional_access_restrictions: boolean
   additional_access_restrictions: string
@@ -128,6 +129,7 @@ export class CreateSerializer extends BaseSerializer<InformationSharingAgreement
       "access_level.is_internal": isInternal,
       "access_level.is_protected_and_limited": isProtectedAndLimited,
       "access_level.is_confidential_and_restricted": isConfidentialAndRestricted,
+      access_level_department_restriction: this.record.accessLevelDepartmentRestriction ?? "undefined",
       department_branch_unit_hierarchy: departmentBranchUnitHierarchy,
       has_additional_access_restrictions: this.record.hasAdditionalAccessRestrictions ?? false,
       additional_access_restrictions: this.record.additionalAccessRestrictions ?? "",

--- a/api/src/serializers/information-sharing-agreements/generate-confidentiality-acknowledgement/create-serializer.ts
+++ b/api/src/serializers/information-sharing-agreements/generate-confidentiality-acknowledgement/create-serializer.ts
@@ -129,7 +129,7 @@ export class CreateSerializer extends BaseSerializer<InformationSharingAgreement
       "access_level.is_internal": isInternal,
       "access_level.is_protected_and_limited": isProtectedAndLimited,
       "access_level.is_confidential_and_restricted": isConfidentialAndRestricted,
-      access_level_department_restriction: this.record.accessLevelDepartmentRestriction ?? "undefined",
+      access_level_department_restriction: this.record.accessLevelDepartmentRestriction ?? "",
       department_branch_unit_hierarchy: departmentBranchUnitHierarchy,
       has_additional_access_restrictions: this.record.hasAdditionalAccessRestrictions ?? false,
       additional_access_restrictions: this.record.additionalAccessRestrictions ?? "",


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/TK-70

# Context

Key `access_level_department_restriction` in template `confidentiality-acknowledgement-template.docx` was missing in `api/src/serializers/information-sharing-agreements/generate-confidentiality-acknowledgement/create-serializer.ts`

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Create ISA with "Access level" **PROTECTED and LIMITED**
5. Download the confidentiality acknowledgement, this will use the template
6. Open downloaded file (ie should be named like `Confidentiality Acknowledgement, TEST - 1, 2026-06-02.docx`)
7. Go to section 4 "Authorised access" 
8. Ensure `access_level_department_restriction` was correctly populated in the "PROTECTED and LIMITED" 