### PR TITLE
Repair Traditional Knowledge Guidance Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ This project is using [knex](https://knexjs.org/guide/migrations.html#migration-
 
 NOTE: Migrations should use snake_case. While database table and column names use snake_case, we are using Sequelize for our models so that we get camelCase to match the JS standard, in the JS section of the codebase.
 
-1. To create a new migration from the template [sample-migration](./api/src/db/template/sample-migration.ts) do:
+1. To create a new migration from the template [sample-migration](./api/src/db/templates/sample-migration.ts) do:
 
    ```bash
    dev migrate make create-users-table

--- a/agents/README.md
+++ b/agents/README.md
@@ -182,7 +182,7 @@ ls -li .cursor/workflows/
 
 If you need agent-specific versions, you can:
 
-1. **Keep in `agents/[agent-name]/`** instead of hardlinking:
+1. **Keep in a dedicated `agents/` subdirectory for that agent** instead of hardlinking:
    ```bash
    mkdir -p agents/claude/workflows
    cp agents/workflows/create-admin-ui.md agents/claude/workflows/

--- a/agents/templates/README.md
+++ b/agents/templates/README.md
@@ -27,7 +27,7 @@ templates/
 ## Usage
 
 Templates are referenced by workflows. See:
-- [create-admin-ui](../workflows/create-admin-ui/) - Full CRUD admin interface
+- [create-admin-ui](../workflows/create-admin-ui.md) - Full CRUD admin interface
 
 Each template file contains:
 1. Location path for the new file

--- a/agents/workflows/create-admin-ui.md
+++ b/agents/workflows/create-admin-ui.md
@@ -37,11 +37,11 @@ Templates are located in `agents/templates/` for reuse across workflows.
 
 | Template | Location | Description |
 |----------|----------|-------------|
-| [Model](../../templates/backend/model.md) | `api/src/models/` | Sequelize model with scopes |
-| [Controller](../../templates/backend/controller.md) | `api/src/controllers/` | CRUD endpoints |
-| [Policy](../../templates/backend/policy.md) | `api/src/policies/` | Authorization rules |
-| [Services](../../templates/backend/services.md) | `api/src/services/{resources}/` | Create, Update, Destroy |
-| [Serializers](../../templates/backend/serializers.md) | `api/src/serializers/{resources}/` | Index, Show, Reference |
+| [Model](../templates/backend/model.md) | `api/src/models/` | Sequelize model with scopes |
+| [Controller](../templates/backend/controller.md) | `api/src/controllers/` | CRUD endpoints |
+| [Policy](../templates/backend/policy.md) | `api/src/policies/` | Authorization rules |
+| [Services](../templates/backend/services.md) | `api/src/services/{resources}/` | Create, Update, Destroy |
+| [Serializers](../templates/backend/serializers.md) | `api/src/serializers/{resources}/` | Index, Show, Reference |
 
 **Integration Points:**
 - `api/src/controllers/index.ts` - Export controller
@@ -52,10 +52,10 @@ Templates are located in `agents/templates/` for reuse across workflows.
 
 | Template | Location | Description |
 |----------|----------|-------------|
-| [API Client](../../templates/frontend/api-client.md) | `web/src/api/` | Type-safe HTTP client |
-| [Composables](../../templates/frontend/composables.md) | `web/src/use/` | Reactive data fetching |
-| [Components](../../templates/frontend/components.md) | `web/src/components/{resources}/` | DataTable, Forms, UniqueTextField |
-| [Pages](../../templates/frontend/pages.md) | `web/src/pages/admin/{resources}/` | List, New, Edit pages |
+| [API Client](../templates/frontend/api-client.md) | `web/src/api/` | Type-safe HTTP client |
+| [Composables](../templates/frontend/composables.md) | `web/src/use/` | Reactive data fetching |
+| [Components](../templates/frontend/components.md) | `web/src/components/{resources}/` | DataTable, Forms, UniqueTextField |
+| [Pages](../templates/frontend/pages.md) | `web/src/pages/admin/{resources}/` | List, New, Edit pages |
 
 **Integration Points:**
 - `web/src/routes.ts` - Add routes


### PR DESCRIPTION
## Related links

Closes #46

## Context

Traditional Knowledge is now included in the downstream guidance audit list. The shared strict audit found stale migration/template/workflow links.

## Implementation

- Fixed the migration-template README link.
- Reworded illustrative `agents/` guidance so strict audit does not treat it as a missing literal path.
- Fixed the create-admin-ui workflow link.
- Corrected backend and frontend template links in `agents/workflows/create-admin-ui.md`.

## Screenshots

N/A — docs/guidance-only change.

## Testing instructions

Run from `klondikemarlen/marlens-skills-rules-and-tools`:

```bash
node bin/agent-guidance-audit.js --json --strict /home/marlen/code/icefoganalytics/traditional-knowledge-issue-46-guidance-audit-cleanup
```

Run from this branch/worktree:

```bash
git diff --check
```

Observed:

- strict audit: PASS, output `[]`.
- whitespace check: PASS, no output.
- No app tests run; changed files are Markdown guidance only.